### PR TITLE
LX-495: Basic ansible role to install Drush 8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+This software is Copyright © 2018 The Regents of the University of
+California. All Rights Reserved.
+
+Permission to copy, modify, and distribute this software and its
+documentation for educational, research and non-profit purposes,
+without fee, and without a written agreement is hereby granted,
+provided that the above copyright notice, this paragraph and the
+following three paragraphs appear in all copies.
+
+Permission to make commercial use of this software may be obtained by
+contacting:
+
+Technology Transfer Office
+10889 Wilshire Blvd, Suite 920
+Los Angeles, CA 90095-7191
+(310) 794-0558
+info@tdg.ucla.edu
+
+This software program and documentation are copyrighted by The Regents
+of the University of California. The software program and
+documentation are supplied "as is", without any accompanying services
+from The Regents. The Regents does not warrant that the operation of
+the program will be uninterrupted or error-free. The end-user
+understands that the program was developed for research purposes and
+is advised not to rely exclusively on the program for any reason.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND
+ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THE UNIVERSITY OF
+CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS
+IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# uclalib_role_drush
+# UCLALib Ansible Role: Drush
+
+Ansible role to install Drush (and Composer).
+
+## Requirements
+
+PHP 5.4.5 or later, to support Drush 8.
+
+## Variables
+
+See `defaults/main.yml`.  The only variable which should be changed is `drush_version`, which should be the latest build of Drush 8.
+
+## Example Playbook:
+```
+---
+- name: Install Drush
+  become: yes
+  become_method: sudo
+  hosts: 127.0.0.1
+  connection: local
+
+  vars:
+    php_pkgs:
+      - php
+      (other php packages as desired)
+
+  roles:
+    - uclalib_role_php
+    - uclalib_role_drush
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+composer_path: /usr/local/bin/composer
+composer_keep_updated: false
+
+composer_home_path: '~/.composer'
+composer_home_owner: root
+composer_home_group: root
+
+# We can use Drush 8.x since we're upgrading to PHP 5.4.5+
+drush_version: "8.1.17"
+drush_phar_url: https://github.com/drush-ops/drush/releases/download/{{ drush_version }}/drush.phar
+drush_path: /usr/local/bin/drush
+

--- a/tasks/composer.yml
+++ b/tasks/composer.yml
@@ -1,0 +1,41 @@
+# Tasks were grabbed from Jeff Geerling's ansible composer role. We didn't need all components.
+# https://github.com/geerlingguy/ansible-role-composer
+---
+
+- name: Check if Composer is installed.
+  stat: 
+    path={{ composer_path }}
+  register: composer_bin
+
+- name: Download Composer installer.
+  get_url:
+    url: https://getcomposer.org/installer
+    dest: /tmp/composer-installer.php
+    mode: 0755
+  when: not composer_bin.stat.exists
+
+- name: Run Composer installer.
+  command: >
+    /usr/bin/php composer-installer.php
+    chdir=/tmp
+  when: not composer_bin.stat.exists
+
+- name: Move Composer into globally-accessible location.
+  shell: >
+    mv /tmp/composer.phar {{ composer_path }}
+    creates={{ composer_path }}
+  when: not composer_bin.stat.exists
+
+- name: Ensure composer directory exists.
+  file:
+    path: "{{ composer_home_path }}"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_group }}"
+    state: directory
+
+- name: Update Composer to latest version (if configured).
+  shell: >
+    php {{ composer_path }} self-update
+  register: composer_update
+  changed_when: "'Updating to version' in composer_update.stdout"
+  when: composer_keep_updated

--- a/tasks/drush.yml
+++ b/tasks/drush.yml
@@ -1,0 +1,24 @@
+---
+# Following tasks are taken from Jeff Geerling's ansible roles
+# https://github.com/geerlingguy/ansible-role-drush
+
+- name: Check current state.
+  stat:
+    path: "{{ drush_path }}"
+  register: drush_path_state
+
+- name: Perform cleanup of old symlink.
+  file:
+    path: "{{ drush_path }}"
+    state: absent
+  when: drush_path_state.stat.islnk is defined and drush_path_state.stat.islnk
+
+- name: Install Drush.
+  get_url:
+    url: "{{ drush_phar_url }}"
+    dest: "{{ drush_path }}"
+
+- name: Ensure Drush is executable.
+  file:
+    path: "{{ drush_path }}"
+    mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Install composer
+  include_tasks: composer.yml
+  include_tasks: drush.yml
+


### PR DESCRIPTION
@cachemeoutside Here's the minimum needed to install Drush 8.

I mostly lifted it from `ansible_uclalib_role_drupal`, but I left out the `druadmin` account creation/config for drush.  That might be desirable on servers but is overkill for dev/sandbox environments.

Once merged, we can add the role to `ansible_uclalib_plays/sandbox/www.library.ucla.edu/requirements.yml` and all should work

Thanks --Andy