### PR TITLE
LX-495: Add meta/main.yml to make ansible-galaxy happy; separate tasks in tasks/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,14 @@
+---
+
+dependencies: []
+
+galaxy_info:
+  author: "Andy Kohler- https://github.com/akohler/"
+  description: "Drush Role to install"
+  company: "UCLA Library"
+  license: "reference license.txt"
+  min_ansible_version:
+  platforms:
+  - name: EL
+    versions:
+    - 7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,7 @@
 
 - name: Install composer
   include_tasks: composer.yml
+
+- name: Install drush
   include_tasks: drush.yml
 


### PR DESCRIPTION
@cachemeoutside This resolves an ansible-galaxy error due to missing `meta/main.yml`, and cleans up `tasks/main.yml` a bit.